### PR TITLE
feat: add SKIP_LOGIN input

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,30 @@ jobs:
           args: push ${GITHUB_REPOSITORY}:${IMAGE_TAG}
 ```
 
+### CLI
+
+```bash
+name: Run docker CLI
+
+on:
+   push:
+     branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Use Docker
+        uses: actions-hub/docker/cli@master
+        env:
+          SKIP_LOGIN: true
+
+      - run: docker --version
+```
+
 ## Licence
 [MIT License](https://github.com/actions-hub/docker/blob/master/LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
     description: 'Docker password'
   DOCKER_REGISTRY_URL:
     description: 'Docker registry url'
+  SKIP_LOGIN:
+    description: 'Skip login'
 runs:
   using: 'docker'
   image: './cli/Dockerfile'

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ ! -e "$HOME/.docker/config.json" ]; then
+if [ ! -e "$HOME/.docker/config.json" ] && [ -z "${SKIP_LOGIN}" ]; then
     echo "::error::Not authorized. Please use login action to authorize to registry. Exiting...."
     exit 1
 fi


### PR DESCRIPTION
Hello! :wave: 
Thanks for this GitHub Action.

Currently it is not possible to only use the `cli` Action, we must login first before using it.
In my workflow I want to use Docker and `docker` CLI, but I don't need to push anything to the registry.
So I want to be able to do something like that :
```yml
ci:
    runs-on: 'ubuntu-latest'
    steps:
      - uses: 'actions/checkout@v2'

      - name: 'Use Docker'
        uses: 'actions-hub/docker/cli@master'
        env:
          SKIP_LOGIN: true

      - run: 'docker --version'
 ```
  `docker --version` is only an example, and it is quite "stupid', I'm doing others things.